### PR TITLE
Use Bundler's new BUNDLE_ONLY in Rubocop workflow

### DIFF
--- a/shared/rubocop.yml
+++ b/shared/rubocop.yml
@@ -22,7 +22,7 @@ jobs:
     name: Run rubocop
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: ${{ vars.REVIEWDOG_RUBOCOP_BUNDLE_WITHOUT || 'default development test release docs' }}
+      BUNDLE_ONLY: ${{ vars.REVIEWDOG_RUBOCOP_BUNDLE_ONLY || 'rubocop' }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This simplifies the config and source repo approach for the Rubocop workflow. Previously, you had to specify all the other groups to exclude.

https://github.com/rails/rails/commit/cd223db81464d5e1cb5168ea7e39e5e3ba419b50

https://github.com/rubygems/rubygems/pull/5759